### PR TITLE
Made mysql queries safer in forensic-mysql.py

### DIFF
--- a/forensic-mysql.py
+++ b/forensic-mysql.py
@@ -292,7 +292,6 @@ for num in id_list:
 	for part in msg.walk():
 		if part.get_content_type() == 'message/feedback-report':
 			feedbackreport = part.get_payload()
-			pprint.pprint(feedbackreport)
 			feedbackreportitems = feedbackreport[0].items()
 		elif part.get_content_type() == 'message/rfc822' and not rfc822Found:
 			msg2 = part.get_payload()
@@ -395,13 +394,13 @@ for num in id_list:
 		if orgpart.get_content_maintype() == 'text':
 			orgmsgpart = orgpart.get_payload(decode=True)
 
-						signal.signal(signal.SIGALRM, handleTimeOut)
-						signal.alarm(30)
-						try:
-			  urls = urls + match_urls.findall(orgmsgpart)
-						except Exception, err:
-						  print ' A error: %s with %s' % (str(err),orgmsgpart)
-						signal.alarm(0)
+			signal.signal(signal.SIGALRM, handleTimeOut)
+			signal.alarm(30)
+			try:
+				urls = urls + match_urls.findall(orgmsgpart)
+			except Exception, err:
+				print ' A error: %s with %s' % (str(err),orgmsgpart)
+				signal.alarm(0)
 		else:
 			if ctype == 'message/delivery-status':
 				bounce = True
@@ -419,9 +418,9 @@ for num in id_list:
 		o = urlparse.urlparse(url[0])
 		urlReport=True
 		for domain in wldomain:
-					if o.hostname is not None and o.hostname[-len(domain):]==domain:
-						urlReport=False
-				if urlReport==True:
+			if o.hostname is not None and o.hostname[-len(domain):]==domain:
+				urlReport=False
+		if urlReport==True:
 			try:
 				reportanswers = dns.resolver.query(o.hostname, 'A')
 				ip = reportanswers[0].to_text()


### PR DESCRIPTION
Unfortunately, MySQLdb isn't the best way to access a MySQL database in python.

Usually, to safely make SQL queries and to prevent injection (to either falsify data or to insert multiple queries), I'd use [SQL parameterization](http://www.codinghorror.com/blog/2005/04/give-me-parameterized-sql-or-give-me-death.html). However, MySQLdb doesn't offer that. Thankfully, it does offer some basic escaping. I fixed `forensic-mysql.py` as an example on how to use it.

It basically needs to be used...everywhere anyone could insert data into the database.Many of these fields I could've previously manipulated by sending malformed emails to the IMAP user that lafayette reads from.

If you want to go through and redo the SQL portions, the best tool for the job is `SQLAlchemy`. It's a bit different since it's ORM (it maps objects to database tables), but it means that you don't need to type out SQL queries in your code, and it automatically parameterizes your queries. `oursql` also offers parameterization, but isn't an ORM.

The other change of note here is that in many places, I replaced the `%` syntax with the newer `format()` method. `%` is deprecated and will be removed in a future version of python. String concatenation with `+` is also frowned upon, though not deprecated. You should move to the `format` method in new code, and gradually transition existing code.
