### PR TITLE
Added some more configurability wrt imap and web

### DIFF
--- a/forensic-mysql.py
+++ b/forensic-mysql.py
@@ -42,6 +42,7 @@ dbPassword=config.get('db','dbPassword')
 imapHost=config.get('mailbox','imapHost')
 imapUser=config.get('mailbox','imapUser')
 imapPassword=config.get('mailbox','imapPassword')
+imapPort = config.get('mailbox', 'imapPort')
 
 wldomain=config.get('dnsbl','wldomain').split(",")
 
@@ -254,7 +255,7 @@ topurl={}
 db=MySQLdb.connect(host=dbHost,user=dbUser,passwd=dbPassword,db=dbName)
 db.autocommit(True)
 
-imap = imaplib.IMAP4_SSL(imapHost)
+imap = imaplib.IMAP4_SSL(imapHost, port=imapPort)
 imap.login(imapUser, imapPassword)
 r, data = imap.select('INBOX')
 r, data = imap.search(None, sentsince)

--- a/forensic.cfg
+++ b/forensic.cfg
@@ -8,6 +8,8 @@ dbPassword = password
 secret_key = secret
 reportSender = postmaster@example.com
 mailSmtp = mail.example.com
+host = 0.0.0.0
+port = 5000
 
 [dnsbl]
 zen = zen.spamhaus.org

--- a/forensic.cfg
+++ b/forensic.cfg
@@ -17,6 +17,7 @@ wldomain = example.com,example.net
 imapHost = localhost
 imapUser = failures
 imapPassword = password
+imapPort = 993
 
 [reports]
 email = feed@example.net

--- a/forensic.py
+++ b/forensic.py
@@ -31,6 +31,7 @@ import signal
 import urlparse
 import tempfile
 import subprocess
+import sys
 
 from ConfigParser import SafeConfigParser
 
@@ -64,6 +65,14 @@ dbPassword=config.get('db','dbPassword')
 reportEmailCc=config.get('reports','email')
 reportEmailSpamCc=config.get('reports','emailSpam')
 arfPassword=config.get('reports','arfPassword')
+
+listen_addr = config.get('web', 'host')
+
+try:
+	listen_port = int(config.get('web', 'port'))
+except ValueError:
+	print "port must be an integer"
+	sys.exit(1)
 
 zen=config.get('dnsbl','zen')
 wldomain=config.get('dnsbl','wldomain').split(",")
@@ -808,4 +817,4 @@ def reportSpam():
 
 if __name__ == '__main__':
     title = "Lafayette"
-    app.run(host='0.0.0.0',debug=True)
+    app.run(host=listen_addr, port=listen_port, debug=True)


### PR DESCRIPTION
I added some additional options, since I didn't like the fact that I couldn't configure them in the config file.

Also, this comes with some recommendations. `imaplib` in base is shit. I don't use SSL on my IMAP server; I use TLS (for my personal mail server, I'm the only user, so I'm free to make this decision). `imaplib` doesn't support starttls (that's just fucking absurd). Neither does `imapclient` (the other popular IMAP python lib). I don't know what the fuck the python devs are doing.

I was going to get the socket from `imaplib` and wrap it in an SSL socket, but since the authors of `imaplib` didn't make it a property, I can't actually do that. So you're shit out of luck wrt. TLS support.
