### PR TITLE
No message/feedback-report part causes abort

### DIFF
--- a/forensic-mysql.py
+++ b/forensic-mysql.py
@@ -309,6 +309,7 @@ for num in id_list:
 	liautosubmitted = ""
 	rfc822Found = False
 	bounce=False
+	feedbackreportitems = []
 	for part in msg.walk():
 		if part.get_content_type() == 'message/feedback-report':
 			feedbackreport = part.get_payload()


### PR DESCRIPTION
Currently, if a message in `id_list` doesn't have a message/feedback-report part, it will cause the script to abort immediately. If this is early in the list, it causes mails to be dropped.

This patch initializes `feedbackreportitems` so that a bad mail is non-fatal.
